### PR TITLE
Use an abstract IWebosEglWindow interface to manipulate the EGL window.

### DIFF
--- a/qwebosscreen.cpp
+++ b/qwebosscreen.cpp
@@ -42,6 +42,7 @@
 #include "qwebosscreen.h"
 #include "qweboswindow.h"
 
+#include <assert.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <linux/fb.h>

--- a/qweboswindow.h
+++ b/qweboswindow.h
@@ -54,14 +54,14 @@
 #include <SysMgrKeyEventTraits.h>
 #include <SysMgrTouchEventTraits.h>
 
-#include <OffscreenNativeWindow.h>
+#include <EGL/egl.h>
 
 class PIpcChannel;
+class IWebosEglWindow;
 
 QT_BEGIN_NAMESPACE
 
-class QWebosWindow : public QPlatformWindow,
-                     public OffscreenNativeWindow
+class QWebosWindow : public QPlatformWindow
 {
 public:
     QWebosWindow(QWebosWindowManagerClient *client, QWindow *w, QWebosScreen *screen);
@@ -88,6 +88,7 @@ public:
     PIpcChannel* channel() const; // Required by IPC_MESSAGE_FORWARD
 
 private:
+    IWebosEglWindow *m_webosEglWindow;
     WId mWinid;
     QWebosWindowManagerClient *mClient;
     QWebosScreen *mScreen;


### PR DESCRIPTION
This interface is defined in libwebos-gui, so the dependancy to libhybris itself is not needed anymore.

Nota Bene: this PR belongs to the following set of PR for webOS-ports: libwebos-gui, qt-webos-plugin, webappmanager, luna-sysmgr and meta-webos-ports and qt5-webos-plugin.
